### PR TITLE
remove unneeded dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   ],
   "dependencies": {
     "@owstack/bitcoind-rpc": "^0.0.1",
-    "@owstack/btc-explorer-api": "^0.0.3",
     "@owstack/btc-lib": "^0.0.3",
     "async": "^2.5.0",
     "body-parser": "^1.13.3",


### PR DESCRIPTION
explorer-api does not belong in this package.json... it goes into the one generated by the scaffold when needed.